### PR TITLE
[#9] feat: 1단계 약관 동의 화면 구현

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,10 @@
 <script setup>
 import { ref } from 'vue'
+import TermsView from './views/TermsView.vue'
 </script>
 
 <template>
-  <div></div>
+  <TermsView />
 </template>
 
 <style lang="scss" scoped></style>

--- a/src/components/Terms/TermsButton.vue
+++ b/src/components/Terms/TermsButton.vue
@@ -1,0 +1,32 @@
+<script setup>
+// 버튼 텍스트 및 비활성화 여부를 props로 받아 재사용
+defineProps({
+  label: {
+    type: String,
+    default: '다음',
+  },
+  disabled: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+defineEmits(['click'])
+</script>
+
+<template>
+  <button
+    @click="$emit('click')"
+    :disabled="disabled"
+    :class="[
+      'w-full py-4 font-bold text-base rounded-2xl transition-colors duration-200',
+      disabled
+        ? 'bg-zinc-200 text-zinc-400 cursor-not-allowed'
+        : 'bg-kb-yellow hover:bg-kb-yellow-light text-white',
+    ]"
+  >
+    {{ label }}
+  </button>
+</template>
+
+<style lang="scss" scoped></style>

--- a/src/components/Terms/TermsCheckBox.vue
+++ b/src/components/Terms/TermsCheckBox.vue
@@ -1,0 +1,85 @@
+<script setup>
+import { useUserStore } from '../../stores/user'
+
+const userStore = useUserStore()
+</script>
+
+<template>
+  <div class="flex flex-col gap-3">
+
+    <!-- 전체 동의하기 -->
+    <button
+      @click="userStore.toggleAll"
+      :class="[
+        'flex items-center gap-3 w-full px-4 py-4 rounded-2xl border transition-colors duration-200',
+        userStore.allChecked
+          ? 'bg-amber-50 border-kb-yellow'
+          : 'bg-white border-zinc-200',
+      ]"
+    >
+      <!-- 체크 아이콘 -->
+      <span
+        :class="[
+          'flex items-center justify-center w-6 h-6 rounded-full flex-shrink-0',
+          userStore.allChecked ? 'bg-kb-yellow' : 'border-2 border-zinc-300',
+        ]"
+      >
+        <svg
+          v-if="userStore.allChecked"
+          class="w-3.5 h-3.5 text-white"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="3"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </span>
+      <span class="font-bold text-kb-dark-gray text-base">전체 동의하기</span>
+    </button>
+
+    <!-- 개별 약관 항목 -->
+    <button
+      v-for="term in userStore.terms"
+      :key="term.id"
+      @click="userStore.toggleTerm(term.id)"
+      class="flex items-center gap-3 w-full px-4 py-4 bg-white rounded-2xl border border-zinc-200 transition-colors duration-200"
+    >
+      <!-- 체크 아이콘 -->
+      <span
+        :class="[
+          'flex items-center justify-center w-6 h-6 rounded-full flex-shrink-0',
+          term.checked ? 'bg-kb-yellow' : 'border-2 border-zinc-300',
+        ]"
+      >
+        <svg
+          v-if="term.checked"
+          class="w-3.5 h-3.5 text-white"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="3"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </span>
+
+      <!-- 약관명 (필수 항목은 굵게 표시) -->
+      <span :class="['text-sm text-kb-gray text-left flex-1', term.required && 'font-bold']">{{ term.label }}</span>
+
+      <!-- 상세보기 화살표 -->
+      <svg
+        class="w-4 h-4 text-kb-gray flex-shrink-0"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
+
+  </div>
+</template>
+
+<style lang="scss" scoped></style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
+import './assets/main.css'
+
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
-
 import App from './App.vue'
 import router from './router'
 

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -1,0 +1,74 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export const useUserStore = defineStore('user', () => {
+  // ────────────────────────────────────────────
+  // 단계 상태
+  // ────────────────────────────────────────────
+  const currentStep = ref(1)
+  const totalSteps = ref(3)
+
+  // ────────────────────────────────────────────
+  // 약관 목록
+  // ────────────────────────────────────────────
+  const terms = ref([
+    { id: 1, label: '[필수] 이용약관 동의', required: true, checked: false },
+    { id: 2, label: '[필수] 개인정보 처리방침', required: true, checked: false },
+    { id: 3, label: '[필수] 금융거래 정보 제공 동의', required: true, checked: false },
+    { id: 4, label: '[선택] 마케팅 정보 수신 동의', required: false, checked: false },
+  ])
+
+  // ────────────────────────────────────────────
+  // 계산된 상태
+  // ────────────────────────────────────────────
+
+  // 전체 동의 여부
+  const allChecked = computed(() => terms.value.every((t) => t.checked))
+
+  // 필수 약관 전체 동의 여부 (다음 버튼 활성화 조건)
+  const requiredAllChecked = computed(() =>
+    terms.value.filter((t) => t.required).every((t) => t.checked),
+  )
+
+  // ────────────────────────────────────────────
+  // 액션
+  // ────────────────────────────────────────────
+
+  // 전체 약관 토글
+  function toggleAll() {
+    const next = !allChecked.value
+    terms.value.forEach((t) => (t.checked = next))
+  }
+
+  // 개별 약관 토글
+  function toggleTerm(id) {
+    const term = terms.value.find((t) => t.id === id)
+    if (term) term.checked = !term.checked
+  }
+
+  // 다음 단계로 이동
+  function nextStep() {
+    if (currentStep.value < totalSteps.value) {
+      currentStep.value++
+    }
+  }
+
+  // 이전 단계로 이동
+  function prevStep() {
+    if (currentStep.value > 1) {
+      currentStep.value--
+    }
+  }
+
+  return {
+    currentStep,
+    totalSteps,
+    terms,
+    allChecked,
+    requiredAllChecked,
+    toggleAll,
+    toggleTerm,
+    nextStep,
+    prevStep,
+  }
+})

--- a/src/views/TermsView.vue
+++ b/src/views/TermsView.vue
@@ -1,0 +1,56 @@
+<script setup>
+import TermsCheckBox from '../components/Terms/TermsCheckBox.vue'
+import TermsButton from '../components/Terms/TermsButton.vue'
+import { useUserStore } from '../stores/user'
+
+const userStore = useUserStore()
+</script>
+
+<template>
+  <div class="min-h-dvh bg-stone-50 flex flex-col px-5 pt-6 pb-8">
+
+    <!-- 뒤로 버튼 -->
+    <button
+      @click="userStore.prevStep"
+      class="flex items-center gap-1 text-sm text-kb-gray hover:text-kb-dark-gray transition-colors duration-200 w-fit"
+    >
+      <span class="text-base leading-none">&lt;</span>
+      <span>뒤로</span>
+    </button>
+
+    <!-- 진행 단계 표시 -->
+    <div class="flex items-center gap-2 mt-5">
+      <div
+        v-for="step in userStore.totalSteps"
+        :key="step"
+        :class="[
+          'h-2 rounded-full transition-all duration-300',
+          step === userStore.currentStep ? 'w-7 bg-kb-yellow' : 'w-2 bg-zinc-300',
+        ]"
+      />
+      <span class="text-xs text-kb-gray ml-1">
+        {{ userStore.currentStep }} / {{ userStore.totalSteps }}단계
+      </span>
+    </div>
+
+    <!-- 타이틀 영역 -->
+    <h1 class="text-2xl font-bold text-kb-dark-gray mt-6 leading-snug">약관에 동의해주세요</h1>
+    <p class="text-sm text-kb-gray mt-1">서비스 이용을 위해 약관 동의가 필요합니다</p>
+
+    <!-- 약관 체크박스 -->
+    <div class="mt-6 flex-1">
+      <TermsCheckBox />
+    </div>
+
+    <!-- 다음 버튼 (필수 약관 전체 동의 시 활성화) -->
+    <TermsButton
+      class="mt-8"
+      label="다음"
+      :disabled="!userStore.requiredAllChecked"
+      @click="userStore.nextStep"
+    />
+
+  </div>
+</template>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
📄 설명
1단계 약관 동의 화면 구현

✅ 작업할 내용
전체 동의
필수 3개(이용약관, 개인정보 처리방침, 금융거래 정보 제공)
선택 1개(마케팅 수신) 항목.
필수 약관 미동의 시 다음 단계 진행 불가.
각 약관 상세 보기 버튼 포함