### PR TITLE
[FIX] 챌린지 카드 초과 시 이미지 즉시 반영 및 색상 통일

### DIFF
--- a/src/components/challenge/ChallengeCard.vue
+++ b/src/components/challenge/ChallengeCard.vue
@@ -20,7 +20,7 @@ const props = defineProps({
   },
   amount: {
     type: Number,
-    default: 1000000,
+    default: 90000,
   },
   weekStatus: {
     type: Number,
@@ -56,14 +56,19 @@ const progressBarRef = ref(null)
 const mounted = ref(false)
 onMounted(() => {
   mounted.value = true
-  if (progressBarRef.value) {
-    progressBarWidth.value = progressBarRef.value.offsetWidth
 
-    const ro = new ResizeObserver(() => {
-      progressBarWidth.value = progressBarRef.value.offsetWidth
-    })
-    ro.observe(progressBarRef.value)
-  }
+  const el = progressBarRef.value
+  if (!el) return
+
+  progressBarWidth.value = el.offsetWidth
+
+  const ro = new ResizeObserver(() => {
+    if (el) {
+      progressBarWidth.value = el.offsetWidth
+    }
+  })
+
+  ro.observe(el)
 })
 
 // 초과 여부, 초과 금액
@@ -96,27 +101,22 @@ const characterStyle = computed(() => {
 
 <template>
   <div
-    class="px-4 py-3 rounded-[24px] shadow-sm relative flex flex-col justify-between overflow-visible"
-    style="background-color: var(--color-kb-yellow)"
+    class="bg-kb-yellow px-4 py-3 rounded-[24px] shadow-sm relative flex flex-col justify-between overflow-visible"
   >
     <!-- 상단 정보 -->
     <div class="leading-tight space-y-0.5">
-      <span
-        class="text-[10px] px-2 py-0.5 rounded-full font-medium"
-        style="background-color: rgba(0, 0, 0, 0.1); color: var(--color-kb-gray)"
-        >{{ currentMonth }}월 진행 중</span
-      >
-      <h2 class="text-xl font-bold mt-0.5" style="color: var(--color-kb-dark-gray)">{{ title }}</h2>
-      <p class="text-[11px] opacity-70" style="color: var(--color-kb-gray)">
-        {{ category }} · {{ periodText }}
-      </p>
+      <span class="text-[10px] px-2 py-0.5 rounded-full font-medium bg-black/10 text-kb-gray">
+        {{ currentMonth }}월 진행 중
+      </span>
+      <h2 class="text-xl font-bold mt-0.5 text-kb-dark-gray">{{ title }}</h2>
+      <p class="text-[11px] opacity-70 text-kb-gray">{{ category }} · {{ periodText }}</p>
     </div>
 
     <!-- 사용 금액 -->
     <div class="flex justify-between items-end mb-0.5">
       <div>
-        <p class="text-[11px] opacity-70" style="color: var(--color-kb-gray)">사용 금액</p>
-        <p class="text-xl font-extrabold leading-none" style="color: var(--color-kb-expense)">
+        <p class="text-[11px] opacity-70 text-kb-gray">사용 금액</p>
+        <p class="text-xl font-extrabold leading-none text-kb-expense">
           {{ amount.toLocaleString() }}<span class="text-lg ml-0.5">원</span>
         </p>
       </div>
@@ -125,11 +125,7 @@ const characterStyle = computed(() => {
       <div class="mb-1">
         <div
           class="text-[10px] font-bold px-2 py-1 rounded-full shadow-sm"
-          :style="
-            isOver
-              ? 'background-color: var(--color-kb-icon-pink); color: var(--color-kb-expense);'
-              : 'background-color: var(--color-kb-icon-green); color: var(--color-kb-income);'
-          "
+          :class="isOver ? 'bg-kb-icon-pink text-kb-expense' : 'bg-kb-icon-green text-kb-income'"
         >
           {{
             isOver ? `${overAmount.toLocaleString()}원 초과` : `${saved.toLocaleString()}원 남음`
@@ -141,8 +137,9 @@ const characterStyle = computed(() => {
     <!-- 진행바 + 캐릭터 영역 -->
     <div class="relative pt-3 mb-2">
       <!-- 라무 캐릭터 -->
-      <div class="absolute bottom-[30%] z-10" :style="characterStyle">
+      <div class="absolute bottom-[25%] z-10" :style="characterStyle">
         <img
+          :key="isOver ? 'end' : 'push'"
           :src="currentImg"
           alt="character"
           :class="[isOver ? 'w-16 h-11' : 'w-11 h-11']"
@@ -152,24 +149,15 @@ const characterStyle = computed(() => {
 
       <!-- 진행바 영역 -->
       <div ref="progressBarRef" class="w-full">
-        <div
-          class="w-full h-2.5 rounded-full overflow-hidden"
-          style="background-color: rgba(0, 0, 0, 0.1)"
-        >
+        <div class="w-full h-2.5 rounded-full overflow-hidden bg-black/10">
           <div
             class="h-full rounded-full transition-all duration-500"
-            :style="{
-              width: progressPercent + '%',
-              background: 'var(--gradient-kb-yellow)',
-            }"
+            :style="{ width: progressPercent + '%', background: 'var(--gradient-kb-yellow)' }"
           ></div>
         </div>
 
         <!-- 진행바 눈금 -->
-        <div
-          class="flex justify-between text-[9px] mt-2 font-medium opacity-60 px-1"
-          style="color: var(--color-kb-gray)"
-        >
+        <div class="flex justify-between text-[9px] mt-2 font-medium opacity-60 px-1 text-kb-gray">
           <span>0원</span>
           <span>{{ (maxAmount / 2).toLocaleString() }}원</span>
           <span>{{ maxAmount.toLocaleString() }}원</span>
@@ -182,19 +170,19 @@ const characterStyle = computed(() => {
       <div
         v-for="i in 4"
         :key="i"
-        class="text-center py-1 rounded-xl text-[11px] font-bold transition-all"
-        :style="
+        class="text-center py-1 rounded-xl text-[11px] font-bold transition-all text-kb-dark-gray"
+        :class="
           i === weekStatus
-            ? 'background-color: var(--gradient-kb-yellow); color: white; box-shadow: 0 2px 4px rgba(0,0,0,0.1); transform: scale(1.05);'
+            ? 'bg-kb-yellow text-white shadow-sm scale-105'
             : i < weekStatus
-              ? 'background-color: rgba(255,255,255,0.6); color: var(--color-kb-dark-gray);'
-              : 'background-color: rgba(255,255,255,0.28); color: var(--color-kb-dark-gray);'
+              ? 'bg-white/60'
+              : 'bg-white/30'
         "
       >
         {{ i }}주
         <div
           class="text-[9px] font-normal opacity-80"
-          :style="i < weekStatus ? 'color: var(--color-kb-income)' : ''"
+          :class="i < weekStatus ? 'text-kb-income' : ''"
         >
           <span v-if="i < weekStatus">완료</span>
           <span v-else-if="i === weekStatus">진행중</span>

--- a/src/components/challenge/MissionCard.vue
+++ b/src/components/challenge/MissionCard.vue
@@ -13,24 +13,24 @@ const missions = ref([
 
 <template>
   <div class="mission-section mt-4 px-1">
-    <h3 class="text-lg font-bold text-[#1A1A1A] mb-2">이번 주 미션</h3>
+    <h3 class="text-lg font-bold text-kb-profit mb-2">이번 주 미션</h3>
 
     <div class="space-y-3">
       <div
         v-for="mission in missions"
         :key="mission.id"
-        class="flex items-center justify-between p-4 h-[56px] bg-white rounded-[20px] shadow-sm border border-gray-50"
+        class="flex items-center justify-between p-4 h-[56px] bg-white rounded-[20px] shadow-sm border border-kb-divider"
       >
         <div class="flex items-center gap-2">
           <div class="w-10 h-10 flex items-center justify-center">
             <img :src="mission.icon" alt="mission-icon" class="w-6 h-6" />
           </div>
-          <span class="font-bold text-[15px] text-gray-900">{{ mission.title }}</span>
+          <span class="font-bold text-[15px] text-kb-profit">{{ mission.title }}</span>
         </div>
 
         <div
           class="w-8 h-8 rounded-full flex items-center justify-center transition-colors"
-          :class="mission.isCompleted ? 'bg-[#FFBC00]' : 'bg-gray-100'"
+          :class="mission.isCompleted ? 'bg-kb-yellow' : 'bg-kb-divider'"
         >
           <img :src="iconMap.check" alt="check" class="w-4 h-4 scale-110" />
         </div>

--- a/src/components/challenge/RankingList.vue
+++ b/src/components/challenge/RankingList.vue
@@ -34,49 +34,49 @@ const myRanking = computed(() => {
     <!-- 제목 -->
     <div class="flex items-center gap-1 mb-2">
       <img :src="iconMap.trophy" alt="trophy" class="w-5 h-5" />
-      <h3 class="text-lg font-bold text-[#1A1A1A]">절약 랭킹</h3>
+      <h3 class="text-lg font-bold text-kb-profit">절약 랭킹</h3>
     </div>
 
     <!-- 랭킹 리스트 -->
     <div class="flex flex-col gap-3">
-      <div class="bg-white rounded-[20px] overflow-hidden border border-gray-50 shadow-sm">
+      <div class="bg-kb-card rounded-[20px] overflow-hidden border border-kb-divider shadow-sm">
         <div
           v-for="(item, index) in topFour"
           :key="item.rank"
           class="flex items-center justify-between px-3 py-2"
-          :class="{ 'border-b border-gray-100': index !== 3 }"
+          :class="{ 'border-b border-kb-divider': index !== 3 }"
         >
           <div class="flex items-center gap-4">
             <span
               class="text-base font-bold w-4 text-center"
               :class="
                 item.rank === 1
-                  ? 'text-[#FFBC00]'
+                  ? 'text-kb-yellow'
                   : item.rank === 2
-                    ? 'text-gray-500'
+                    ? 'text-kb-muted'
                     : item.rank === 3
-                      ? 'text-[#A05030]'
-                      : 'text-gray-300'
+                      ? 'text-kb-empty'
+                      : 'text-kb-line'
               "
             >
               {{ item.rank }}
             </span>
             <div
-              class="w-10 h-10 rounded-full bg-[#FFF9E5] flex items-center justify-center text-[#8A6800] font-bold"
+              class="w-10 h-10 rounded-full bg-kb-icon-yellow flex items-center justify-center text-kb-dark-gray font-bold"
             >
               {{ item.initial }}
             </div>
             <div>
-              <p class="font-bold text-[14px] text-gray-900 leading-tight">{{ item.name }}</p>
-              <p class="text-[11px] text-gray-400 font-medium">{{ item.category }}</p>
+              <p class="font-bold text-[14px] text-kb-profit leading-tight">{{ item.name }}</p>
+              <p class="text-[11px] text-kb-muted font-medium">{{ item.category }}</p>
             </div>
           </div>
 
           <div class="text-right">
-            <p class="font-bold text-[14px] text-gray-900 leading-tight">
+            <p class="font-bold text-[14px] text-kb-profit leading-tight">
               {{ item.spent.toLocaleString() }}원
             </p>
-            <p class="text-[11px] text-[#00A361] font-semibold opacity-80">
+            <p class="text-[11px] text-kb-income font-semibold opacity-80">
               {{ item.saved.toLocaleString() }}원 절약
             </p>
           </div>
@@ -85,30 +85,30 @@ const myRanking = computed(() => {
 
       <div
         v-if="myRanking"
-        class="flex items-center justify-between p-4 h-[56px] rounded-[20px] bg-[#FFF9D6] border-2 border-[#FFBC00] shadow-sm"
+        class="flex items-center justify-between p-4 h-[56px] rounded-[20px] bg-kb-card-yellow border-2 border-kb-yellow shadow-sm"
       >
         <div class="flex items-center gap-4">
-          <span class="text-base font-bold w-4 text-center text-[#8A6800]">{{
+          <span class="text-base font-bold w-4 text-center text-kb-dark-gray">{{
             myRanking?.rank
           }}</span>
           <div
-            class="w-10 h-10 rounded-full bg-[#FFBC00] flex items-center justify-center text-[#8A6800] font-bold"
+            class="w-10 h-10 rounded-full bg-kb-yellow flex items-center justify-center text-kb-dark-gray font-bold"
           >
             {{ myRanking?.initial }}
           </div>
           <div>
-            <p class="font-bold text-[14px] text-gray-900 leading-tight">{{ myRanking?.name }}</p>
-            <p class="text-[11px] text-[#8A6800] opacity-60 font-medium">
+            <p class="font-bold text-[14px] text-kb-profit leading-tight">{{ myRanking?.name }}</p>
+            <p class="text-[11px] text-kb-dark-gray opacity-60 font-medium">
               {{ myRanking?.category }}
             </p>
           </div>
         </div>
 
         <div class="text-right">
-          <p class="font-bold text-[14px] text-gray-900 leading-tight">
+          <p class="font-bold text-[14px] text-kb-profit leading-tight">
             {{ myRanking?.spent?.toLocaleString() }}원
           </p>
-          <p class="text-[11px] text-[#00A361] font-semibold">
+          <p class="text-[11px] text-kb-income font-semibold">
             {{ myRanking?.saved?.toLocaleString() }}원 절약중
           </p>
         </div>


### PR DESCRIPTION
## 작업 내용

- [x] img에 :key 추가로 금액 초과 시 이미지 즉시 교체
- [x] 챌린지 화면 색상 값을 main.css CSS 변수로 통일