### PR TITLE
fix: SummaryView 월별 데이터 정렬 오류 수정

### DIFF
--- a/src/views/SummaryView.vue
+++ b/src/views/SummaryView.vue
@@ -32,7 +32,9 @@ onMounted(async () => {
     if (t.type === 'income') monthMap[month].income += t.amount
     else monthMap[month].expense += t.amount
   })
-  monthlyData.value = Object.values(monthMap).sort((a, b) => a.month.localeCompare(b.month))
+  monthlyData.value = Object.values(monthMap).sort(
+    (a, b) => parseInt(a.month) - parseInt(b.month),
+  )
 
   // 카테고리별 데이터 가공 (지출만)
   const categoryMap = {}


### PR DESCRIPTION
문자열 비교(localeCompare)로 인한 10월 이후 정렬 오류를 숫자 비교(parseInt)로 수정