### PR TITLE
[FIX] 금액 표기 통일 (천원단위 버림, 만원 표기)

### DIFF
--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,11 +1,11 @@
+// 천원 단위까지 표현, 100원 이하 버림 (예: 39,450원 → 3.9만원)
 export const formatCompactWon = (amount) => {
-  const absoluteAmount = Math.abs(amount)
-
-  if (absoluteAmount >= 1000000) {
-    return `${Math.round(absoluteAmount / 10000).toLocaleString()}만원`
+  const abs = Math.abs(amount)
+  if (abs >= 10000) {
+    const value = Math.floor(abs / 1000) / 10
+    return `${value.toLocaleString()}만원`
   }
-
-  return `${Math.round(absoluteAmount / 10000).toLocaleString()}만원`
+  return `${abs.toLocaleString()}원`
 }
 
 export const formatSignedWon = (amount) => {

--- a/src/views/SummaryView.vue
+++ b/src/views/SummaryView.vue
@@ -3,6 +3,7 @@ import { ref, computed, onMounted } from 'vue'
 import { getTransactions } from '@/api/transaction'
 import { iconMap } from '@/utils/icons'
 import { useAuthStore } from '@/stores/user'
+import { formatCompactWon } from '@/utils/format'
 
 const categoryIconMap = {
   주거: iconMap.home,
@@ -94,10 +95,7 @@ function barY(value) {
 }
 
 function formatAmount(value) {
-  if (Math.abs(value) >= 10000) {
-    return (value / 10000).toLocaleString() + '만원'
-  }
-  return value.toLocaleString() + '원'
+  return formatCompactWon(value)
 }
 
 function profitSign(value) {


### PR DESCRIPTION
제곧내